### PR TITLE
Add additional threat modeling models and blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,6 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
  - [ECS Fargate Threat Modeling](https://sysdig.com/blog/ecs-fargate-threat-modeling/)
 
- - [Amazon S3](https://controlcatalog.trustoncloud.com/dashboard/aws/s3#Data%20Flow%20Diagram)
-
  - [IETF Trans Threat Analysis](https://datatracker.ietf.org/doc/html/draft-ietf-trans-threat-analysis-16)
 
  - [Secure Password Storage](https://owasp.org/www-pdf-archive//Secure_Password_Storage.pdf)
@@ -209,6 +207,8 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Container Threat Model](https://github.com/krol3/container-security-checklist#container-threat-model)
 
 - [Account Takeover Threat Model](https://raw.githubusercontent.com/magoo/ato-checklist/master/model.svg)
+
+- [Amazon S3](https://controlcatalog.trustoncloud.com/dashboard/aws/s3#Data%20Flow%20Diagram)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [Secure Slack bot an exercise in threat modeling](https://diablohorn.com/2019/11/18/secure-slack-bot-an-exercise-in-threat-modeling/)
 
-- [DNS Security: Threat Modeling DNSSEC, DoT, and DoH](https://www.netmeister.org/blog/doh-dot-dnssec.html)
-
 - [Threat Modeling Process](https://owasp.org/www-community/Threat_Modeling_Process)
  
 - [Developers Guide Securing Mobile Applications](https://www.synopsys.com/content/dam/synopsys/sig-assets/ebooks/developers-guide-securing-mobile-applications-threat-modeling.pdf)
@@ -190,6 +188,8 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [ISO/SAE 21434 Annex G Example](https://github.com/Yakindu/YSA-examples)
 
 - [Docker Threat Model](https://cloudsecdocs.com/container_security/theory/threats/docker_threat_model/)
+
+- [DNS Security: Threat Modeling DNSSEC, DoT, and DoH](https://www.netmeister.org/blog/doh-dot-dnssec.html)
 
 - [Container Threat Model](https://github.com/krol3/container-security-checklist#container-threat-model)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [Threat Modeling or Whiteboard Hacking training](https://www.toreon.com/threatmodeling/)
 
+- [Kubernetes Threat Modeling](https://learning.oreilly.com/live-events/kubernetes-threat-modeling/0636920055610/0636920059945/)
 
 ## Videos
 
@@ -170,10 +171,14 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [ECS Fargate Threat Modeling](https://sysdig.com/blog/ecs-fargate-threat-modeling/)
 
+- [Kubernetes Attack Trees](https://github.com/cncf/financial-user-group/tree/main/projects/k8s-threat-model)
+
 
 ## Threat Model examples
 
 *Threat model examples for reference.*
+
+- [DNS Security: Threat Modeling DNSSEC, DoT, and DoH](https://www.netmeister.org/blog/doh-dot-dnssec.html)
 
 - [OAuth 2.0 Threat Model and Security Considerations](https://datatracker.ietf.org/doc/html/rfc6819)
 
@@ -183,13 +188,11 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [OWASP Threat Model Cookbook](https://github.com/OWASP/threat-model-cookbook)
 
-- [Kubernetes Threat Model](https://github.com/cncf/financial-user-group/tree/main/projects/k8s-threat-model)
+- [Kubernetes Threat Model](https://github.com/kubernetes/sig-security/tree/main/sig-security-external-audit/security-audit-2019/findings)
 
 - [ISO/SAE 21434 Annex G Example](https://github.com/Yakindu/YSA-examples)
 
 - [Docker Threat Model](https://cloudsecdocs.com/container_security/theory/threats/docker_threat_model/)
-
-- [DNS Security: Threat Modeling DNSSEC, DoT, and DoH](https://www.netmeister.org/blog/doh-dot-dnssec.html)
 
 - [Container Threat Model](https://github.com/krol3/container-security-checklist#container-threat-model)
 
@@ -232,6 +235,13 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [MAL](https://mal-lang.org) - MAL is an open source project that supports creation of cyber threat modeling systems and attack simulations. 
 
 - [Threagile](https://github.com/Threagile/threagile) - Threagile is an open-source toolkit for agile threat modeling
+
+- [TicTaaC](https://github.com/rusakovichma/TicTaaC) - Threat modeling-as-a-Code in a Tick (TicTaaC). Lightweight and easy-to-use Threat modeling solution following DevSecOps principles
+
+- [Threat Modeling Online Game](https://github.com/dehydr8/elevation-of-privilege) - Online version of the Elevation of Privilege and Cornucopia card games. The easy way to get started with threat modeling.
+
+- [Deciduous](https://github.com/rpetrich/deciduous) - A web app that simplifies building attack decision trees. Hosted at https://www.deciduous.app/
+
 
 ### Paid tools
 

--- a/README.md
+++ b/README.md
@@ -178,9 +178,15 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
  - [ECS Fargate Threat Modeling](https://sysdig.com/blog/ecs-fargate-threat-modeling/)
 
+ - [Amazon S3](https://controlcatalog.trustoncloud.com/dashboard/aws/s3#Data%20Flow%20Diagram)
+
  - [IETF Trans Threat Analysis](https://datatracker.ietf.org/doc/html/draft-ietf-trans-threat-analysis-16)
 
  - [Secure Password Storage](https://owasp.org/www-pdf-archive//Secure_Password_Storage.pdf)
+
+ - [Human Threat Model](https://github.com/JWWeatherman/human_threat_model)
+
+ - [Smart Home Threat Model](https://github.com/kkredit/smart-home-threat-model)
 
 ## Threat Model examples
 
@@ -190,13 +196,9 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [SSL Threat model by Qualys](https://www.ssllabs.com/downloads/SSL_Threat_Model.png)
 
-- [DNS Security: Threat Modeling DNSSEC, DoT, and DoH by Jan Schuamann](https://www.netmeister.org/blog/doh-dot-dnssec.html)
-
 - [Email Encryption Gateway Threat model by NCC Group](https://www.slideshare.net/NCC_Group/real-world-application-threat-modelling-by-example)
 
 - [OWASP Threat Model Cookbook](https://github.com/OWASP/threat-model-cookbook)
-
-- [Kubernetes Threat Model](https://github.com/kubernetes/community/tree/master/sig-security/security-audit-2019/findings)
 
 - [K8 Threat Model](https://github.com/cncf/financial-user-group/tree/main/projects/k8s-threat-model)
 
@@ -207,8 +209,6 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Container Threat Model](https://github.com/krol3/container-security-checklist#container-threat-model)
 
 - [Account Takeover Threat Model](https://raw.githubusercontent.com/magoo/ato-checklist/master/model.svg)
-
-- [SSL Threat Model](https://www.ssllabs.com/downloads/SSL_Threat_Model.png)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MQNDKF5');</script>
-<!-- End Google Tag Manager -->
-
-
-
-
 # Awesome Threat Modeling [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 [<img src="images/awesome-threat-modelling.png">](https://www.practical-devsecops.com/devsecops-university/)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,29 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [Secure Slack bot an exercise in threat modeling](https://diablohorn.com/2019/11/18/secure-slack-bot-an-exercise-in-threat-modeling/)
 
+- [DNS Security: Threat Modeling DNSSEC, DoT, and DoH](https://www.netmeister.org/blog/doh-dot-dnssec.html)
+
+- [Playbook for Threat Modeling Medical Devices](https://www.mitre.org/sites/default/files/publications/Playbook-for-Threat-Modeling-Medical-Devices.pdf)
+
+- [Threat Modeling Trinity](https://github.com/juliocesarfort/public-pentesting-reports/blob/master/COMSATS_Islamabad-CyberSecurityLab/Threat_Modeling_Trinity_Wallet.pdf)
+
+ - [Threat Modeling Contact Tracing Applications](https://www.linkedin.com/pulse/threat-modeling-contact-tracing-applications-jakub-kaluzny/)
+
+ - [Threat Modeling Process](https://owasp.org/www-community/Threat_Modeling_Process)
+ 
+ - [Developers Guide Securing Mobile Applications](https://www.synopsys.com/content/dam/synopsys/sig-assets/ebooks/developers-guide-securing-mobile-applications-threat-modeling.pdf)
+
+ - [Finding Vulnerabilities In Swiss Posts](https://www.reversemode.com/2022/01/finding-vulnerabilities-in-swiss-posts.html?m=1#AttackSurface)
+
+ - [Threat Matrix  CI/CD](https://github.com/rung/threat-matrix-cicd)
+
+ - [Top 10 CI/CD Security Risks](https://github.com/cider-security-research/top-10-cicd-security-risks)
+
+ - [ECS Fargate Threat Modeling](https://sysdig.com/blog/ecs-fargate-threat-modeling/)
+
+ - [IETF Trans Threat Analysis](https://datatracker.ietf.org/doc/html/draft-ietf-trans-threat-analysis-16)
+
+ - [Secure Password Storage](https://owasp.org/www-pdf-archive//Secure_Password_Storage.pdf)
 
 ## Threat Model examples
 
@@ -175,9 +198,17 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [Kubernetes Threat Model](https://github.com/kubernetes/community/tree/master/sig-security/security-audit-2019/findings)
 
+- [K8 Threat Model](https://github.com/cncf/financial-user-group/tree/main/projects/k8s-threat-model)
+
 - [ISO/SAE 21434 Annex G Example](https://github.com/Yakindu/YSA-examples)
 
+- [Docker Threat Model](https://cloudsecdocs.com/container_security/theory/threats/docker_threat_model/)
 
+- [Container Threat Model](https://github.com/krol3/container-security-checklist#container-threat-model)
+
+- [Account Takeover Threat Model](https://raw.githubusercontent.com/magoo/ato-checklist/master/model.svg)
+
+- [SSL Threat Model](https://www.ssllabs.com/downloads/SSL_Threat_Model.png)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MQNDKF5');</script>
+<!-- End Google Tag Manager -->
+
+
+
 
 # Awesome Threat Modeling [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 

--- a/README.md
+++ b/README.md
@@ -160,31 +160,18 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [DNS Security: Threat Modeling DNSSEC, DoT, and DoH](https://www.netmeister.org/blog/doh-dot-dnssec.html)
 
-- [Playbook for Threat Modeling Medical Devices](https://www.mitre.org/sites/default/files/publications/Playbook-for-Threat-Modeling-Medical-Devices.pdf)
-
-- [Threat Modeling Trinity](https://github.com/juliocesarfort/public-pentesting-reports/blob/master/COMSATS_Islamabad-CyberSecurityLab/Threat_Modeling_Trinity_Wallet.pdf)
-
- - [Threat Modeling Contact Tracing Applications](https://www.linkedin.com/pulse/threat-modeling-contact-tracing-applications-jakub-kaluzny/)
-
- - [Threat Modeling Process](https://owasp.org/www-community/Threat_Modeling_Process)
+- [Threat Modeling Process](https://owasp.org/www-community/Threat_Modeling_Process)
  
- - [Developers Guide Securing Mobile Applications](https://www.synopsys.com/content/dam/synopsys/sig-assets/ebooks/developers-guide-securing-mobile-applications-threat-modeling.pdf)
+- [Developers Guide Securing Mobile Applications](https://www.synopsys.com/content/dam/synopsys/sig-assets/ebooks/developers-guide-securing-mobile-applications-threat-modeling.pdf)
 
- - [Finding Vulnerabilities In Swiss Posts](https://www.reversemode.com/2022/01/finding-vulnerabilities-in-swiss-posts.html?m=1#AttackSurface)
+- [Finding Vulnerabilities In Swiss Posts](https://www.reversemode.com/2022/01/finding-vulnerabilities-in-swiss-posts.html?m=1#AttackSurface)
 
- - [Threat Matrix  CI/CD](https://github.com/rung/threat-matrix-cicd)
+- [Threat Matrix  CI/CD](https://github.com/rung/threat-matrix-cicd)
 
- - [Top 10 CI/CD Security Risks](https://github.com/cider-security-research/top-10-cicd-security-risks)
+- [Top 10 CI/CD Security Risks](https://github.com/cider-security-research/top-10-cicd-security-risks)
 
- - [ECS Fargate Threat Modeling](https://sysdig.com/blog/ecs-fargate-threat-modeling/)
+- [ECS Fargate Threat Modeling](https://sysdig.com/blog/ecs-fargate-threat-modeling/)
 
- - [IETF Trans Threat Analysis](https://datatracker.ietf.org/doc/html/draft-ietf-trans-threat-analysis-16)
-
- - [Secure Password Storage](https://owasp.org/www-pdf-archive//Secure_Password_Storage.pdf)
-
- - [Human Threat Model](https://github.com/JWWeatherman/human_threat_model)
-
- - [Smart Home Threat Model](https://github.com/kkredit/smart-home-threat-model)
 
 ## Threat Model examples
 
@@ -209,6 +196,20 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Account Takeover Threat Model](https://raw.githubusercontent.com/magoo/ato-checklist/master/model.svg)
 
 - [Amazon S3](https://controlcatalog.trustoncloud.com/dashboard/aws/s3#Data%20Flow%20Diagram)
+
+- [Playbook for Threat Modeling Medical Devices](https://www.mitre.org/sites/default/files/publications/Playbook-for-Threat-Modeling-Medical-Devices.pdf)
+
+- [Threat Modeling Trinity](https://github.com/juliocesarfort/public-pentesting-reports/blob/master/COMSATS_Islamabad-CyberSecurityLab/Threat_Modeling_Trinity_Wallet.pdf)
+
+- [Threat Modeling Contact Tracing Applications](https://www.linkedin.com/pulse/threat-modeling-contact-tracing-applications-jakub-kaluzny/)
+
+- [Secure Password Storage](https://owasp.org/www-pdf-archive//Secure_Password_Storage.pdf)
+
+- [Human Threat Model](https://github.com/JWWeatherman/human_threat_model)
+
+- [Smart Home Threat Model](https://github.com/kkredit/smart-home-threat-model)
+
+- [IETF Trans Threat Analysis](https://datatracker.ietf.org/doc/html/draft-ietf-trans-threat-analysis-16)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [OWASP Threat Model Cookbook](https://github.com/OWASP/threat-model-cookbook)
 
-- [K8 Threat Model](https://github.com/cncf/financial-user-group/tree/main/projects/k8s-threat-model)
+- [Kubernetes Threat Model](https://github.com/cncf/financial-user-group/tree/main/projects/k8s-threat-model)
 
 - [ISO/SAE 21434 Annex G Example](https://github.com/Yakindu/YSA-examples)
 


### PR DESCRIPTION
Updating the README file with threat modeling blogs and models from threat model examples [repo](https://github.com/TalEliyahu/Threat_Model_Examples/blob/main/README.md).