### PR TITLE
Add reference to OpenSSF CII project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [IETF Trans Threat Analysis](https://datatracker.ietf.org/doc/html/draft-ietf-trans-threat-analysis-16)
 
+- [OpenSSF CII Threat Models for Open Source Projects (as part of Silver badge criteria)](https://bestpractices.coreinfrastructure.org/de/projects)
+
 ## Tools
 
 *Tools which helps in threat modelling.*

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [The Enchiridion of Impetus Exemplar: A Threat Modeling Field Guide](https://shellsharks.com/threat-modeling)
 
+- [Leveraging Threat Modeling for your SOC/SIEM](https://www.ncsc.gov.uk/collection/building-a-security-operations-centre/onboarding-systems-and-log-sources/threat-modelling)
+
 
 ## Threat Model examples
 


### PR DESCRIPTION
OpenSSF CII is an Open Source community where Open Source communities can apply for a badge indicating the best practices applied by the community. Threat Modeling is a criteria for passing Silver badge of CII. Numerous projects have provided the reference to their TM. Highly recommend to incorporate this as an openly available reference.