### PR TITLE
added Cybersage in Paid tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Foreseeti](https://www.foreseeti.com/) - SecuriCAD Vanguard is an attack simulation and automated threat modeling SaaS service that enables you to automatically simulate attacks on a virtual model of your AWS environment.
 - [Tutamen Threat Model system](https://www.tutamantic.com) - This tool allows threat model metadata to be added to any software diagram, turning that diagram into a threat model. It's simple to use, requires no lock-in license, and is driven by the Common Weakness Enumeration, STRIDE and OWASP Top 10.
 - [YAKINDU Security Analyst](https://www.itemis.com/de/yakindu/security-analyst/) - YAKINDU Security Analyst is a model-based software tool for threat analysis and risk assessment of technical systems. You can identify your protection needs, analyze possible threats and calculate the resulting risks. The underlying assessment model and calculation logic are highly customizable and can be integrated into existing toolchains.
+- [CyberSage Inc.](https://www.cybersage.us/) - With an AI powered Threat Modeling engine, CyberSage incorporates contextual risk data as input including business value and risk, functionality, technology stack and existing controls to produce contextualized threat model. Through automation, CyberSage injects the contextualized threat model into life cycle of software development and security risk management.
+
 
 ## Sponsor
 


### PR DESCRIPTION
Add a reference to paid tool Cybersage Inc.

For reference, the tool is actively available on Jira Marketplace [here](https://marketplace.atlassian.com/apps/1229875/ai-assisted-threat-modeling-saas-powered-by-jira?hosting=cloud&tab=overview) and Microsoft Azure Marketplace [here](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cybersageinc1664851284877.threat-modeling-automation-cybersage?tab=Overview&exp=ubp8) 
