### PR TITLE
Adding additional option for AWS threat modeling for builders, fixing name

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [Leveraging Threat Modeling for your SOC/SIEM](https://www.ncsc.gov.uk/collection/building-a-security-operations-centre/onboarding-systems-and-log-sources/threat-modelling)
 
+- [AWS' How to approach threat modeling](https://aws.amazon.com/blogs/security/how-to-approach-threat-modeling/)
+
 
 ## Threat Model examples
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [drawio-threatmodeling](https://github.com/michenriksen/drawio-threatmodeling) - A collection of custom libraries to turn the free and cross-platform Draw.io diagramming application into the perfect tool for threat modeling.
 
+- [Threat composer](https://github.com/awslabs/threat-composer) - A simple threat modeling tool to help humans to reduce time-to-value when threat modeling. Try the [hosted version](https://awslabs.github.io/threat-composer/) on AWSlabs. Data is persisted only client-side within the browser (100% local storage).
 
 ### Paid tools
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [Threat Modeling Security Fundamentals](https://learn.microsoft.com/en-us/training/paths/tm-threat-modeling-fundamentals/)
 
-- [Threat Modeling the Right Way for Builders Workshop](https://explore.skillbuilder.aws/learn/course/external/view/elearning/13274/threat-modeling-the-right-way-for-builders-workshop) - AWS Skill Builder threat modeling workshop. Requires AWS Skill Builder Login (free).
-
+- Threat Modeling for Builders Workshop is AWS' threat modeling workshop. Available in [AWS Workshop Studio](https://catalog.workshops.aws/threatmodel/en-US), and [AWS Skill Builder](https://explore.skillbuilder.aws/learn/course/external/view/elearning/13274/threat-modeling-the-right-way-for-builders-workshop) (requires free AWS Skill Builder account).
 
 
 ### Paid

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [Threat Modeling Security Fundamentals](https://learn.microsoft.com/en-us/training/paths/tm-threat-modeling-fundamentals/)
 
-- Threat Modeling for Builders Workshop is AWS' threat modeling workshop. Available in [AWS Workshop Studio](https://catalog.workshops.aws/threatmodel/en-US), and [AWS Skill Builder](https://explore.skillbuilder.aws/learn/course/external/view/elearning/13274/threat-modeling-the-right-way-for-builders-workshop) (requires free AWS Skill Builder account).
+- AWS' Threat modeling for builders workshop is available on [AWS Workshop Studio](https://catalog.workshops.aws/threatmodel/en-US), and [AWS Skill Builder](https://explore.skillbuilder.aws/learn/course/external/view/elearning/13274/threat-modeling-the-right-way-for-builders-workshop) (requires free AWS Skill Builder account).
 
 
 ### Paid

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 - [drawio-threatmodeling](https://github.com/michenriksen/drawio-threatmodeling) - A collection of custom libraries to turn the free and cross-platform Draw.io diagramming application into the perfect tool for threat modeling.
 
-- [Threat composer](https://github.com/awslabs/threat-composer) - A simple threat modeling tool to help humans to reduce time-to-value when threat modeling. Try the [hosted version](https://awslabs.github.io/threat-composer/) on AWSlabs. Data is persisted only client-side within the browser (100% local storage).
+- [Threat composer](https://github.com/awslabs/threat-composer) - A simple threat modeling tool to help humans to reduce time-to-value when threat modeling. Try the [hosted version](https://awslabs.github.io/threat-composer/) on awslabs. Data is persisted only client-side within the browser (100% local storage).
 
 ### Paid tools
 


### PR DESCRIPTION
The training is available for free in AWS Workshop Studio, and AWS Skill Builder. 
We've renamed the training Threat modeling for builders (vs Threat modeling the right way).