### PR TITLE
Add TutorialSearch to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Threat Modeling or Whiteboard Hacking training](https://www.toreon.com/threatmodeling/)
 
 - [Kubernetes Threat Modeling](https://learning.oreilly.com/live-events/kubernetes-threat-modeling/0636920055610/0636920059945/)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Videos
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Threat Modeling or Whiteboard Hacking training](https://www.toreon.com/threatmodeling/)
 
 - [Kubernetes Threat Modeling](https://learning.oreilly.com/live-events/kubernetes-threat-modeling/0636920055610/0636920059945/)
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/cybersecurity/cyber-threat) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Videos
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/cybersecurity/cyber-threat) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/cybersecurity/cyber-threat) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.